### PR TITLE
重写了chatpaper 中 section split 的逻辑；更改为两阶段问询。

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 </div>
 </br>
 
+Update: 
+* 重写了 section split 的逻辑, fix 了原本可能出现的抓不到 introduction 和 conclusion 的问题 (比如当 conclusion 的标题是 "conclusions and future works" 的时候).
+* 更改为两个阶段: 先询问 chatgpt 它感兴趣的章节, 随后再发送相应的章节.
+
+---
+
 基于之前ChatPaper的启发，本人在周末开发了这款ChatReviewer，并且开源给大家。
 
 **ChatReviewer是一款基于ChatGPT-3.5的API接口的论文自动审稿AI助手。**

--- a/ReviewFormat.txt
+++ b/ReviewFormat.txt
@@ -20,6 +20,6 @@ Please provide a numbered list of your main concerns regarding this paper (so au
 Please provide a numbered list of specific and clear questions that pertain to the details of the proposed method, evaluation setting, or additional results that would aid in supporting the authors' claims. The questions should be formulated in a manner that, after the authors have answered them during the rebuttal, it would enable a more thorough assessment of the paper's quality. (Maximum length: 2,000 characters)
 xxx
 
-*Overall score (1-5)
-The paper is scored on a scale of 1-5, with 5 being the full mark. Then give the reason for your rating.
+*Overall score (1-10)
+The paper is scored on a scale of 1-10, with 10 being the full mark, and 6 stands for borderline accept. Then give the reason for your rating.
 xxx

--- a/pdf_outline.py
+++ b/pdf_outline.py
@@ -1,0 +1,59 @@
+import fitz
+import re
+from collections import Counter
+import json
+
+doc = fitz.open("input_file/ijcai23.pdf")
+
+# 获取文档中所有字体大小
+font_sizes = []
+for page in doc:
+    blocks = page.get_text("dict")["blocks"]
+    for block in blocks:
+        if 'lines' not in block:
+            continue
+        lines = block["lines"]
+        for line in lines:
+            for span in line["spans"]:
+                font_sizes.append(span["size"])
+
+# 计算出现最频繁的字体大小
+most_common_size, _ = Counter(font_sizes).most_common(1)[0]
+
+# 按照最频繁的字体大小确定标题字体大小的阈值
+threshold = most_common_size * 1
+
+subheadings = []
+# 遍历每一页并查找子标题
+headings = {i: [] for i in range(2)}
+title_font_size = [-1, -1]
+found_abstract = False
+for page in doc:
+    blocks = page.get_text("dict")["blocks"]
+    for block in blocks:
+        if not found_abstract:
+            text = json.dumps(block)
+            if re.search(r"\bAbstract\b", text, re.IGNORECASE):
+                found_abstract = True
+        if found_abstract:
+            if 'lines' not in block:
+                continue
+            lines = block["lines"]
+            for line in lines:
+                for span in line["spans"]:
+                    if span["size"] > threshold and re.match(r"[A-Z][a-z]+(?:\s[A-Z][a-z]+)*", span["text"].strip()):
+                        if title_font_size[0] == -1:  # 第一级标题都没有找到
+                            title_font_size[0] = span["size"]
+                        elif span["size"] < title_font_size[0] and title_font_size[1] == -1:  # 第二级标题都没有找到
+                            title_font_size[1] = span["size"]
+                        if span["size"] == title_font_size[0]:
+                            headings[0].append(span["text"].strip())
+                        elif span["size"] == title_font_size[1]:
+                            headings[1].append(span["text"].strip())
+
+# 打印分级的标题
+for i, level_headings in headings.items():
+    print(f"Level {i} Headings:")
+    for heading in level_headings:
+        print(heading)
+print(subheadings)


### PR DESCRIPTION
* 重写了 section split 的逻辑, fix 了原本可能出现的抓不到 introduction 和 conclusion 的问题 (比如当 conclusion 的标题是 "conclusions and future works" 的时候).
* 更改为两个阶段: 先询问 chatgpt 它感兴趣的章节, 随后再发送相应的章节.