### PR TITLE
fix re.match for section title

### DIFF
--- a/get_paper_from_pdf.py
+++ b/get_paper_from_pdf.py
@@ -157,7 +157,7 @@ class Paper:
                                 section_dict[heading] = ""
                                 last_heading = heading
                             if not upper_heading and span["size"] > threshold and re.match(  # 正常情况下,通过字体大小判断
-                                    r"[A-Z][a-z]+(?:\s[A-Z][a-z]+)*",
+                                    r"[0-9]*\.* *[A-Z][a-z]+(?:\s[A-Z][a-z]+)*",
                                     span["text"].strip()):
                                 font_heading = True
                                 if heading_font == -1:


### PR DESCRIPTION
#10 
I met this problem and found the current pattern can not match the CVPR section title (e.g., "1. Introduction"), containing order and title. It makes all content will be added in "Abstract", and send too many tokens to openai API.
I change the pattern to `[0-9]*\.* *[A-Z][a-z]+(?:\s[A-Z][a-z]+)*`, adding optional number+dot+space before upper character.